### PR TITLE
Ignore the exit code

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,8 +30,10 @@ export function provideLinter () {
     lintOnFly: false,
     lint: function (textEditor) {
       const filePath = textEditor.getPath()
+      const parameters = ['--json', filePath]
+      const options = { ignoreExitCode: true }
 
-      return Helpers.exec('proselint', ['--json', filePath]).then(function (output) {
+      return Helpers.exec('proselint', parameters, options).then(function (output) {
         const errors = JSON.parse(output.toString()).data.errors
 
         return errors.map(function (error) {


### PR DESCRIPTION
This is another linter that exits with a 1 when it finds errors (even if it itself didn't crash).

Fixes https://github.com/AtomLinter/linter-proselint/pull/25#issuecomment-227608633.