### PR TITLE
Update CI configuration

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,24 +1,13 @@
 dependencies:
   override:
-    - curl -L https://atom.io/download/deb -o atom-amd64.deb
-    - sudo dpkg --install atom-amd64.deb || true
-    - sudo apt-get update
-    - sudo apt-get -f install
     - pip install proselint
-    - npm install
+    - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
+    - chmod u+x build-package.sh
 
 test:
   override:
-    - npm run lint
-    # Remove the node_modules installed with the system npm to test real apm install
-    - rm -Rf node_modules
-    - atom -v
-    - apm -v
-    - apm install --production
-    - apm test
+    - ./build-package.sh
 
 machine:
-  node:
-    version: 6
   python:
     version: 3.5.1


### PR DESCRIPTION
* Move to the script on atom/ci for most actions
* Stop installing Node.js v6, the one bundled with Atom is now sufficient