### PR TITLE
Fix proselint timeout by copying 60 seconds hard limit and uniqueKey from linter-bootlint …

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,26 +53,33 @@ export default {
         loadDeps();
         const filePath = textEditor.getPath();
         const parameters = ['--json', filePath];
-        const options = { ignoreExitCode: true };
+	// Fix Error: Process execution timed out for larger files https://github.com/AtomLinter/linter-proselint/issues/4
+	// 60 seconds hard limit and uniqueKey copied from linter-bootlint timeout fix https://github.com/AtomLinter/linter-bootlint/issues/44
+        const options = { ignoreExitCode: true, timeout: 1000 * 60, uniqueKey: `linter-proselint::${filePath}`,};
 
-        const output = await helpers.exec('proselint', parameters, options);
-        const { errors } = JSON.parse(output.toString()).data;
+	// Fix for null return if called before previous exectuion complete
+        output = await helpers.exec('proselint', parameters, options);
+        if (output == null) {
+            output = '{"data": {"errors": []}, "status": "success"}';
+        }
 
-        return errors.map((error) => {
-          const line = error.line - 1;
-          const col = error.column - 1;
-          return {
-            severity: error.type === 'error' ? 'error' : 'warning',
-            excerpt: error.message,
-            location: {
-              file: filePath,
-              position: [
-                [line, col],
-                [line, col + error.extent],
-              ],
-            },
-          };
-        });
+        const errors = JSON.parse(output.toString()).data.errors;
+
+          return errors.map((error) => {
+            const line = error.line - 1;
+            const col = error.column - 1;
+            return {
+              severity: error.type === 'error' ? 'error' : 'warning',
+              excerpt: error.message,
+              location: {
+                file: filePath,
+                position: [
+                  [line, col],
+                  [line, col + error.extent],
+                ],
+              },
+            };
+          });
       },
     };
   },


### PR DESCRIPTION
…and added null check for results

This is a fix for linter-proselint timeouts that occur linting large files with thousands or ten of thousands of lines, originally identified in https://github.com/AtomLinter/linter-proselint/issues/4
Copied a fix from linter-bootlint that added a 60 seconds hard limit to the linting process. Error identified here: https://github.com/AtomLinter/linter-bootlint/issues/44

Also, identified a problem caused by sequential linting requests being invoked before the preceding linting has completed causing the linter to return a null. Caused by CTRL+S saving forced a re-lint before the previous request is finished. Fix is to ignore subsequent lint requests and dummy in a non-null return value.

@Arcanemagus 